### PR TITLE
Update `acorn` and increase default `ecmaVersion`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,5 @@ build/Release
 node_modules
 package-lock.json
 
-lib/*
 /index.js
 /walk.js

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # acorn-node
 
-[Acorn](https://github.com/acornjs/acorn) preloaded with plugins for syntax parity with recent Node versions.
-
-It also includes versions of the plugins compiled with [Babel](https://github.com/babel/babel), so they can be run on old Node versions (0.6 and up).
+[Acorn](https://github.com/acornjs/acorn) with defaults for syntax parity with recent Node versions.
 
 [![npm][npm-image]][npm-url]
 [![travis][travis-image]][travis-url]
@@ -27,14 +25,9 @@ npm install acorn-node
 var acorn = require('acorn-node')
 ```
 
-The API is the same as [acorn](https://github.com/acornjs/acorn), but the following syntax features are enabled by default:
+The API is the same as [acorn](https://github.com/acornjs/acorn) but with different defaults, to match Node modules:
 
- - Public and private class instance fields
- - Public and private class static fields
-
-And the following options have different defaults from acorn, to match Node modules:
-
- - `ecmaVersion: 2021`
+ - `ecmaVersion: 2022`
  - `allowHashBang: true`
  - `allowReturnOutsideFunction: true`
 
@@ -48,9 +41,3 @@ See the [acorn documentation](https://github.com/acornjs/acorn#distwalkjs) for d
 ## License
 
 The files in the repo root and the ./test folder are licensed as [Apache-2.0](LICENSE.md).
-
-The files in lib/ are generated from other packages:
-
-- lib/class-fields: [acorn-class-fields](https://github.com/acornjs/acorn-class-fields), MIT
-- lib/class-private-elements: [acorn-class-private-elements](https://github.com/acornjs/acorn-class-private-elements), MIT
-- lib/static-class-features: [acorn-static-class-features](https://github.com/acornjs/acorn-static-class-features), MIT

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "acorn-node",
-  "description": "the acorn javascript parser, preloaded with plugins for syntax parity with recent node versions",
+  "description": "the acorn javascript parser, with defaults for syntax parity with recent node versions",
   "version": "2.0.1",
   "author": "Renée Kooi <renee@kooi.me>",
   "bugs": {
     "url": "https://github.com/browserify/acorn-node/issues"
   },
   "dependencies": {
-    "acorn": "^7.4.0",
-    "acorn-walk": "^7.2.0",
+    "acorn": "^8.5.0",
+    "acorn-walk": "^8.2.0",
     "setprototypeof": "^1.2.0",
     "xtend": "^4.0.2"
   },
@@ -16,11 +16,7 @@
     "@babel/cli": "^7.10.1",
     "@babel/core": "^7.10.1",
     "@babel/preset-env": "^7.10.1",
-    "acorn-class-fields": "^0.3.4",
-    "acorn-private-class-elements": "^0.2.5",
-    "acorn-static-class-features": "^0.2.2",
     "mkdirp": "^0.5.5",
-    "npm-run-all": "^4.1.5",
     "standard": "^13.1.0",
     "tape": "^4.13.3"
   },
@@ -41,15 +37,6 @@
     "lint": "standard",
     "test": "node test",
     "prepare": "npm run build && node test",
-    "build:acorn-class-fields": "babel node_modules/acorn-class-fields --out-dir lib/acorn-class-fields",
-    "build:acorn-static-class-features": "babel node_modules/acorn-static-class-features --out-dir lib/acorn-static-class-features",
-    "build:acorn-private-class-elements": "babel node_modules/acorn-private-class-elements --out-dir lib/acorn-private-class-elements",
-    "build:self": "babel src --out-dir .",
-    "build": "npm-run-all --parallel build:*"
-  },
-  "standard": {
-    "ignore": [
-      "lib/**/*"
-    ]
+    "build": "babel src --out-dir ."
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,13 @@
 var acorn = require('acorn')
 
 var CJSParser = acorn.Parser
-  // Required paths should be relative to the package root, because Babel outputs this file there.
-  .extend(require('./lib/acorn-class-fields'))
-  .extend(require('./lib/acorn-static-class-features'))
   .extend(defaultOptionsPlugin)
 var ESModulesParser = CJSParser
 
 function mapOptions (opts) {
   if (!opts) opts = {}
   return {
-    ecmaVersion: 2021,
+    ecmaVersion: 2022,
     allowHashBang: true,
     allowReturnOutsideFunction: true,
     ...opts

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ test('parses object spread syntax', function (t) {
 
 test('does not change main acorn module', function (t) {
   t.throws(function () {
-    baseAcorn.parse('var a = 10n')
+    baseAcorn.parse('#!/usr/bin/env node\nconsole.log("ok")', { ecmaVersion: 2021 })
   })
   t.end()
 })


### PR DESCRIPTION
`acorn` has been updated to v8.5, and `acorn-walk` has been updated to v8.2. These versions include many new bug fixes and features, including the features currently being added by this package using plugins. These features are supported by `acorn` only when `ecmaVersion` is set to "2022", so the default `ecmaVersion` has been set to `2022`.

Since the plugins are no longer needed, they have been removed, along with all related build steps and documentation.